### PR TITLE
Fix/fe/review/#139 fix

### DIFF
--- a/backend/src/main/java/com/back/domain/review/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/back/domain/review/review/controller/ReviewController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
@@ -47,25 +48,13 @@ public class ReviewController {
     @GetMapping("/{book_id}/list")
     public RsData<PageResponseDto<ReviewResponseDto>> getReviews(
             @PathVariable("book_id") int bookId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "id") String sortBy,
-            @RequestParam(defaultValue = "desc") String sortDir
+            @PageableDefault(size=10, sort="id", direction=Sort.Direction.DESC) Pageable pageable
             ) {
         Book book = bookRepository.findById(bookId).orElseThrow(() -> new NoSuchElementException("Book not found"));
         Member member = rq.getActor();
         if (member == null) {
             return new RsData<>("401-1", "Unauthorized access");
         }
-        Sort.Direction direction;
-        if (sortDir.equalsIgnoreCase("desc")) {
-            direction = Sort.Direction.DESC;
-        } else if (sortDir.equalsIgnoreCase("asc")) {
-            direction = Sort.Direction.ASC;
-        } else {
-            throw new ServiceException("400-3", "정렬 방향은 'asc' 또는 'desc'만 허용됩니다.");
-        }
-        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
         PageResponseDto<ReviewResponseDto> reviews = reviewService.getPageReviewResponseDto(book, pageable, member);
         return new RsData<>("200-1", "Reviews fetched successfully", reviews);
     }

--- a/backend/src/main/java/com/back/domain/review/review/entity/Review.java
+++ b/backend/src/main/java/com/back/domain/review/review/entity/Review.java
@@ -31,10 +31,29 @@ public class Review extends BaseEntity {
     @Setter
     private int dislikeCount;
 
+    @Version
+    private Long version;
+
     public Review(String content, int rate, Member member, Book book) {
         this.content = content;
         this.rate = rate;
         this.member = member;
         this.book = book;
+    }
+
+    public void incLike(){
+        this.likeCount++;
+    }
+
+    public void decLike(){
+        this.likeCount--;
+    }
+
+    public void incDislike(){
+        this.dislikeCount++;
+    }
+
+    public void decDislike(){
+        this.dislikeCount--;
     }
 }

--- a/backend/src/main/java/com/back/domain/review/review/entity/Review.java
+++ b/backend/src/main/java/com/back/domain/review/review/entity/Review.java
@@ -31,8 +31,8 @@ public class Review extends BaseEntity {
     @Setter
     private int dislikeCount;
 
-    @Version
-    private Long version;
+//    @Version
+//    private Long version;
 
     public Review(String content, int rate, Member member, Book book) {
         this.content = content;

--- a/backend/src/main/java/com/back/domain/review/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/back/domain/review/review/repository/ReviewRepository.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Integer> {
     Optional<Review> findFirstByOrderByIdDesc();
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Review> findById(int id);
 
     Optional<Review> findByBookAndMember(Book book, Member member);

--- a/backend/src/main/java/com/back/domain/review/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/back/domain/review/review/repository/ReviewRepository.java
@@ -3,9 +3,11 @@ package com.back.domain.review.review.repository;
 import com.back.domain.book.book.entity.Book;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.review.review.entity.Review;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +16,9 @@ import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Integer> {
     Optional<Review> findFirstByOrderByIdDesc();
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Review> findById(int id);
 
     Optional<Review> findByBookAndMember(Book book, Member member);
 

--- a/backend/src/main/java/com/back/domain/review/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/back/domain/review/review/repository/ReviewRepository.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Integer> {
     Optional<Review> findFirstByOrderByIdDesc();
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Review> findById(int id);
 
     Optional<Review> findByBookAndMember(Book book, Member member);

--- a/backend/src/main/java/com/back/domain/review/reviewRecommend/controller/ReviewRecommendController.java
+++ b/backend/src/main/java/com/back/domain/review/reviewRecommend/controller/ReviewRecommendController.java
@@ -31,7 +31,6 @@ public class ReviewRecommendController {
 
     @PutMapping("/{review_id}/{is_recommend}")
     public RsData<Void> modifyRecommendReview(@PathVariable("review_id") int reviewId, @PathVariable("is_recommend") boolean isRecommend) {
-        Review review = reviewService.findById(reviewId).orElseThrow(() -> new NoSuchElementException("Review not found"));
         Member member = rq.getActor();
         if (member == null) {
             return new RsData<>("401-1", "Unauthorized access");
@@ -42,7 +41,6 @@ public class ReviewRecommendController {
 
     @DeleteMapping("/{review_id}")
     public RsData<Void> cancelRecommendReview(@PathVariable("review_id") int reviewId) {
-        Review review = reviewService.findById(reviewId).orElseThrow(() -> new NoSuchElementException("Review not found"));
         Member member = rq.getActor();
         if (member == null) {
             return new RsData<>("401-1", "Unauthorized access");

--- a/backend/src/main/java/com/back/domain/review/reviewRecommend/controller/ReviewRecommendController.java
+++ b/backend/src/main/java/com/back/domain/review/reviewRecommend/controller/ReviewRecommendController.java
@@ -21,12 +21,11 @@ public class ReviewRecommendController {
 
     @PostMapping("/{review_id}/{is_recommend}")
     public RsData<Void> recommendReview(@PathVariable("review_id") int reviewId, @PathVariable("is_recommend") boolean isRecommend) {
-        Review review = reviewService.findById(reviewId).orElseThrow(()->new NoSuchElementException("Review not found"));
         Member member = rq.getActor();
         if (member == null) {
             return new RsData<>("401-1", "Unauthorized access");
         }
-        reviewRecommendService.recommendReview(review, member, isRecommend);
+        reviewRecommendService.recommendReview(reviewId, member, isRecommend);
         return new RsData<>("201-1", "Review recommended successfully");
     }
 
@@ -37,7 +36,7 @@ public class ReviewRecommendController {
         if (member == null) {
             return new RsData<>("401-1", "Unauthorized access");
         }
-        reviewRecommendService.modifyRecommendReview(review, member, isRecommend);
+        reviewRecommendService.modifyRecommendReview(reviewId, member, isRecommend);
         return new RsData<>("200-1", "Review recommendation modified successfully");
     }
 
@@ -48,7 +47,7 @@ public class ReviewRecommendController {
         if (member == null) {
             return new RsData<>("401-1", "Unauthorized access");
         }
-        reviewRecommendService.cancelRecommendReview(review, member);
+        reviewRecommendService.cancelRecommendReview(reviewId, member);
         return new RsData<>("200-1", "Review recommendation cancelled successfully");
     }
 }

--- a/backend/src/main/java/com/back/domain/review/reviewRecommend/service/ReviewRecommendService.java
+++ b/backend/src/main/java/com/back/domain/review/reviewRecommend/service/ReviewRecommendService.java
@@ -22,22 +22,6 @@ public class ReviewRecommendService {
     private final ReviewRecommendRepository reviewRecommendRepository;
 
     @Transactional
-    public void recommendReviewInternal(int reviewId, Member member, boolean isRecommend) {
-        Review review = reviewRepository.findById(reviewId).orElseThrow(()->new NoSuchElementException("Review not found"));
-        ReviewRecommend reviewRecommend = new ReviewRecommend(review, member, isRecommend);
-        if (reviewRecommendRepository.findByReviewAndMember(review, member).isPresent()) {
-            throw new ServiceException("400-1", "Review recommendation already exists");
-        }
-        reviewRecommendRepository.save(reviewRecommend);
-        if (isRecommend) {
-            review.incLike();
-        } else {
-            review.incDislike();
-        }
-        reviewRepository.save(review);
-    }
-
-    @Transactional
     public void recommendReview(int reviewId, Member member, boolean isRecommend) {
         Review review = reviewRepository.findById(reviewId).orElseThrow(()->new NoSuchElementException("Review not found"));
         ReviewRecommend reviewRecommend = new ReviewRecommend(review, member, isRecommend);

--- a/backend/src/main/java/com/back/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/back/global/initData/BaseInitData.java
@@ -42,6 +42,7 @@ public class BaseInitData {
     private final BookmarkService bookmarkService;
     private final BookmarkRepository bookmarkRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ReviewRepository reviewRepository;
     @Autowired
     private MemberRepository memberRepository;
 
@@ -49,8 +50,8 @@ public class BaseInitData {
     @Bean
     ApplicationRunner baseInitDataApplicationRunner(){
         return args->{
-//            self.initReviewData(); // 리뷰 테스트 시 주석 해제
             self.initBookData(); // 책 데이터 초기화
+//            self.initReviewData(); // 리뷰 테스트 시 주석 해제
             self.initNoteData(); // Note 관련 데이터
 //            self.initBookmarkData(); // Bookmark 데이터 초기화
         };
@@ -58,11 +59,18 @@ public class BaseInitData {
 
     @Transactional
     public void initReviewData() {
-        if (bookRepository.count() > 0) {
+        int memberCount = 100;
+        if (memberRepository.count() > memberCount) {
             return; // 이미 데이터가 존재하면 초기화하지 않음
         }
-        for (int i = 1; i <= 10; i++) {
+        for (int i = 1; i <= memberCount; i++) {
             memberService.join("testUser" + i, "email" + i + "@a.a", passwordEncoder.encode("password" + i));
+        }
+        Book book = bookRepository.findAll().get(0); // 첫 번째 책을 가져옴
+        for (int i = 1; i <= memberCount; i++) {
+            Member member = memberRepository.findByEmail("email" + i + "@a.a").orElseThrow(() -> new NoSuchElementException("멤버를 찾을 수 없습니다: "));
+            Review review = new Review("리뷰 ㅋㅋ " + i, 5, member, book);
+            reviewRepository.save(review);
         }
 //        Category category = categoryRepository.save(new Category("Test Category"));
 //        bookRepository.save(new Book("Text Book", "Publisher", category));
@@ -189,7 +197,4 @@ public class BaseInitData {
         //bookmarkService.modifyBookmark(member, bookmark1.getId(), "READ", LocalDateTime.of(2025,07,22,12,20), LocalDateTime.now(),book1.getTotalPage());
         //bookmarkService.modifyBookmark(member, bookmark2.getId(), "READING", LocalDateTime.now(), null, 101);
     }
-
-    @Autowired
-    private ReviewRepository reviewRepository;
 }

--- a/backend/src/test/java/com/back/domain/review/reviewRecommend/controller/ReviewRecommendControllerTest.java
+++ b/backend/src/test/java/com/back/domain/review/reviewRecommend/controller/ReviewRecommendControllerTest.java
@@ -1,13 +1,16 @@
 package com.back.domain.review.reviewRecommend.controller;
 
 import com.back.domain.book.book.entity.Book;
+import jakarta.persistence.EntityManager;
 import com.back.domain.book.book.repository.BookRepository;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.member.member.service.MemberService;
 import com.back.domain.review.review.controller.ReviewController;
 import com.back.domain.review.review.entity.Review;
+import com.back.domain.review.review.repository.ReviewRepository;
 import com.back.domain.review.review.service.ReviewService;
+import com.back.domain.review.reviewRecommend.repository.ReviewRecommendRepository;
 import jakarta.servlet.http.Cookie;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +25,9 @@ import org.springframework.test.web.servlet.ResultActions;
 
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -49,6 +55,9 @@ public class ReviewRecommendControllerTest {
 
     @Autowired
     private BookRepository bookRepository;
+
+    @Autowired
+    private ReviewRecommendRepository reviewRecommendRepository;
 
     List<String> makeAccessTokens(int count){
         return memberRepository.findAll().stream()
@@ -367,4 +376,49 @@ public class ReviewRecommendControllerTest {
                 .andExpect(jsonPath("$.msg").value("Review recommendation not found"))
         ;
     }
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("리뷰 동시성 체크 - 성공")
+    void t13() throws Exception{
+        int memberCount = 100;
+        List<String> accessTokens = makeAccessTokens(memberCount);
+        Book book = bookRepository.findAll().get(0);
+        createReview(book.getId(), "이 책 정말 좋았어요!", 5, accessTokens.get(0));
+        Review review = reviewService.findLatest().orElseThrow(()-> new RuntimeException("리뷰가 없습니다."));
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(memberCount);
+        for (int i = 0; i< memberCount; i++){
+            Review finalReview = review;
+            String accessToken = accessTokens.get(i);
+            executor.submit(() -> {
+                try{
+                    ResultActions result = createRecommendReview(finalReview.getId(), true, accessToken);
+                    result
+                            .andExpect(handler().handlerType(ReviewRecommendController.class))
+                            .andExpect(handler().methodName("recommendReview"))
+                            .andExpect(status().isCreated())
+                            .andExpect(jsonPath("$.resultCode").value("201-1"))
+                            .andExpect(jsonPath("$.msg").value("Review recommended successfully"))
+                    ;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        em.clear();
+        long count = reviewRecommendRepository.count();
+        assertThat(count).isEqualTo(memberCount);
+        review = reviewRepository.findById(review.getId()).get();
+        assertThat(review.getLikeCount()).isEqualTo(memberCount);
+    }
+
+    @Autowired
+    private ReviewRepository reviewRepository;
 }

--- a/frontend/src/app/_hooks/useReview.ts
+++ b/frontend/src/app/_hooks/useReview.ts
@@ -69,8 +69,8 @@ export const useReview = (initBookId:number) =>{
     return data;
   }
 
-  const getReviews = async () => {
-    const res = await apiFetch<ApiResponse<PageResponseDto<ReviewResponseDto>>>(`/reviews/${bookId}/list`,{
+  const getReviews = async (page:number) => {
+    const res = await apiFetch<ApiResponse<PageResponseDto<ReviewResponseDto>>>(`/reviews/${bookId}/list?page=${page}`,{
       method:"GET"
     })
     const data:PageResponseDto<ReviewResponseDto> = res.data;

--- a/frontend/src/app/bookmark/[id]/review/page.tsx
+++ b/frontend/src/app/bookmark/[id]/review/page.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { getBookmark } from "@/types/bookmarkAPI";
 import { BookmarkDetail } from "@/types/bookmarkData";
-import { ArrowLeft, Save, Star, UndoIcon, X } from "lucide-react";
+import { ArrowLeft, Save, Star, Trash2, UndoIcon, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { use, useCallback, useEffect, useState } from "react";
 
@@ -84,6 +84,11 @@ export default withLogin(function page({params}:{params:Promise<{id:string}>}){
     }
     onNavigate(`/bookmark/${bookmarkId}`);
   };
+
+  const handleDelete = () =>{
+    reviewApi.deleteReview();
+    onNavigate(`/bookmark/${bookmarkId}`);
+  }
 
   const handleCancel = () => {
     onNavigate(`/bookmark/${bookmarkId}`);
@@ -218,6 +223,10 @@ export default withLogin(function page({params}:{params:Promise<{id:string}>}){
                   <Save className="h-4 w-4 mr-2" />
                   저장하기
                 </Button>
+                {review && <Button variant="destructive" onClick={handleDelete}>
+                  <Trash2></Trash2>
+                  삭제
+                </Button>}
                 <Button 
                   variant="outline"
                   onClick={handleCancel}

--- a/frontend/src/app/bookmark/page.tsx
+++ b/frontend/src/app/bookmark/page.tsx
@@ -259,16 +259,16 @@ interface BookmarkEditFormProps {
 function BookmarkEditForm({ bookmark, onSave, onCancel }: BookmarkEditFormProps) {
   const [formData, setFormData] = useState({
     readState: bookmark.readState,
-    startReadDate: bookmark.startReadDate?.substring(0, 10) || '',
-    endReadDate: bookmark.endReadDate?.substring(0, 10) || '',
+    startReadDate: bookmark.startReadDate?.substring(0, 10) || new Date().toISOString().split("T")[0],
+    endReadDate: bookmark.endReadDate?.substring(0, 10) || new Date().toISOString().split("T")[0],
     readPage: bookmark.readPage || 0,
   });
 
   useEffect(() => {
     setFormData({
       readState: bookmark.readState,
-      startReadDate: bookmark.startReadDate?.substring(0, 10) || '',
-      endReadDate: bookmark.endReadDate?.substring(0, 10) || '',
+      startReadDate: bookmark.startReadDate?.substring(0, 10) || new Date().toISOString().split("T")[0],
+      endReadDate: bookmark.endReadDate?.substring(0, 10) || new Date().toISOString().split("T")[0],
       readPage: bookmark.readPage || 0,
     });
   }, [bookmark]);

--- a/frontend/src/app/books/[bookId]/page.tsx
+++ b/frontend/src/app/books/[bookId]/page.tsx
@@ -45,8 +45,8 @@ export default function page({params}:{params:Promise<{bookId:string}>}){
 
     const loadReviews = async (page: number = 0) => {
       try {
-        const detail = await fetchBookDetail(bookId, page);
-        setBookDetail(prev => prev ? {...prev, reviews: detail.reviews} : detail);
+        const detail = await reviewApi.getReviews(page);
+        setBookDetail({...bookDetail!, reviews: detail});
         setReviewPage(page);
       } catch (err) {
         console.error('리뷰 로드 실패:', err);

--- a/frontend/src/app/books/[bookId]/page.tsx
+++ b/frontend/src/app/books/[bookId]/page.tsx
@@ -13,7 +13,7 @@ import { BookDetailDto, fetchBookDetail, ReviewResponseDto, addToMyBooks, ReadSt
 import { useReview, useReviewRecommend } from "@/app/_hooks/useReview";
 import { useTheme } from "next-themes";
 import { useAuth } from "@/app/_hooks/auth-context";
-import { toast } from "@/lib/toast";
+import { toast } from "sonner";
 
 export default function page({params}:{params:Promise<{bookId:string}>}){
     const {bookId:bookIdStr} = use(params);
@@ -63,8 +63,12 @@ export default function page({params}:{params:Promise<{bookId:string}>}){
     
     const onAddToMyBooks = async (bookId: number) => {
       if (!isLoggedIn) {
-        toast.info("로그인을 해 주세요");
-        router.push("/login");
+        toast.error("로그인을 해 주세요.", {
+          action:{
+            label:"이동",
+            onClick:()=>{onNavigate("/login")}
+          }
+        });
         return;
       }
       
@@ -131,6 +135,15 @@ export default function page({params}:{params:Promise<{bookId:string}>}){
   };
 
   const handleRecommend = async(review:ReviewResponseDto, recommend:boolean)=>{
+    if (!isLoggedIn){
+      toast.error("로그인을 해주세요.", {
+        action: {
+          label:"이동",
+          onClick: ()=>{onNavigate("/login")}
+        }
+      })
+      return;
+    }
     // 업데이트가 늦어질 경우 대비해서 프론트에서 먼저 적용
     const reviews = bookDetail.reviews.data.map((r)=>{
       if (r.id === review.id){
@@ -172,7 +185,7 @@ export default function page({params}:{params:Promise<{bookId:string}>}){
     }else{
       await reviewRecommendApi.modifyReviewRecomend(review.id, recommend);
     }
-    await loadReviews(0);
+    await loadReviews(reviewPage);
   }
 
   return (

--- a/frontend/src/app/books/page.tsx
+++ b/frontend/src/app/books/page.tsx
@@ -36,7 +36,7 @@ import {
   BooksResponse,
 } from "@/types/book";
 import { useAuth } from "@/app/_hooks/auth-context";
-import { toast } from "@/lib/toast";
+import { toast } from "sonner";
 import { createBookmark } from "@/types/bookmarkAPI.js";
 import { getCategories, Category } from "@/types/category";
 
@@ -238,8 +238,12 @@ export default function BooksPage() {
 
   const addToMyBooks = async (bookId: number, status: string) => {
     if (!isLoggedIn) {
-      toast.info("로그인을 해 주세요");
-      router.push("/login");
+      toast.error("로그인을 해주세요.", {
+        action: {
+          label:"이동",
+          onClick: ()=>{router.push("/login")}
+        }
+      })
       return;
     }
     


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
리뷰 시스템을 수정했다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
6283125 [#139]refactor: 성능을 위해 lock을 도입
> 시도는 했지만 값이 반영되는 것 같지 않아서 다른 방식을 시도 했다.
> ReviewRecommend의 개수를 count하는 query를 사용하면 개수가 많아지면 많아질수록 
> 추천을 하는 작업이 무거워지기 때문에 수정했다.

e88fb0b [#139]refactor: optimisticLock 도입(실패)
> 시도는 했지만 확률적으로만 20%만 성공하고 나머지는 실패했다.

a0e9784 [#139]refactor: Lock 어노테이션 활용(성공)
> EntityManager의 1차 캐시를 초기화하니 다른 스레드의 커밋이 반영되어서 성공했다.

94d8a06 [#139]fix: book이 먼저 초기화가 되어야 함
> baseInit 파일에서 review가 위에 있는데 book이 먼저 초기화가 되어야 테스트 코드가 실행된다.

51ced47 [#139]feat: 100명의 동시 테스트 성공
> 주석 처리된 코드 제거했고 100명의 멤버를 만들어서 20개를 한번에 처리하는 스레드 풀을 만들어서 동시성 테스트를 했다.

7d5fd93 [#139]refactor: bookRequest 따라서 수정
> book에서 하는 것과 같이 controller를 수정했습니다.

e0b81c7 [#139]refactor:review
> alert 띄우고 바로 이동하는 것 보다는 toast 띄우고 버튼 눌러서 로그인 페이지로 이동하는게 어떤가 생각해서 수정했습니다.
<img width="390" height="99" alt="image" src="https://github.com/user-attachments/assets/255e7b80-6657-4535-89bf-0f5edaf41441" />


05f2a16 [#139]refactor: 리뷰만 가져오기
> 7d5fd93 에서 작업한 거 반영 시켰습니다.

4a955bd [#139]fix: bookmark에서 발생 오류 수정
> 북마크의 읽기 시작 일과 읽기 종료 일을 기본 값을 오늘로 수정했습니다.

9d1e1ed [#139]feat: 삭제 추가
> 수정하러 들어가면 삭제 버튼을 추가했고 삭제가 가능합니다.

<!--## ✅ 피드백 반영사항   지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
e0b81c7 에서 FE에서 book page, book/[id] page의 toast를 수정했습니다.
4a955bd 에서 FE에서 bookmark page의 읽기 시작일, 종료일의 초기값을 오늘(버튼 클릭 당시의 오늘)로 수정했습니다.
현재 작업하는 것과 충돌이 발생할 수 있다고 판단되면 말해주세요.

close #139 